### PR TITLE
#10 adding missing force true for uploadPackage

### DIFF
--- a/src/main/java/com/adobe/cq/testing/client/PackageManagerClient.java
+++ b/src/main/java/com/adobe/cq/testing/client/PackageManagerClient.java
@@ -526,6 +526,7 @@ public class PackageManagerClient extends CQClient {
     public Package uploadPackage(InputStream is, String fileName) throws ClientException {
         HttpEntity mpe = MultipartEntityBuilder.create()
                 .addPart("package", new InputStreamBody(is, fileName))
+                .addTextBody("force", "true")
                 .addTextBody("_charset_", "UTF-8")
                 .build();
 


### PR DESCRIPTION
@volteanu it was used in one of the 2 variation of the uploadPackage signature only which explains the issue with the UsePackageRule which is based on the one where it is missing.

