### PR TITLE
@trivial update to latest version that include 503 retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.clients</artifactId>
-            <version>1.2.4</version>
+            <version>1.2.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>


### PR DESCRIPTION
As seen recently 503 may produce flakyness in tests execution, new release of sling testing client introduce retries for 503.
