### PR TITLE
ensure locale is set to english for locale dependent date formatted tests

### DIFF
--- a/src/test/java/com/adobe/cq/testing/client/PackageManagerClientTest.java
+++ b/src/test/java/com/adobe/cq/testing/client/PackageManagerClientTest.java
@@ -19,11 +19,17 @@ import org.junit.Test;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 
 public class PackageManagerClientTest {
+
+    static {
+        // date formats below are expected to be formatted in english locale
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @Test
     public void testBuildPackageFromJson() throws Exception {


### PR DESCRIPTION
Running the tests on my "German" terminal failed as JVM uses german as the default locale and that has an impact on the date formats e.g. [here](https://github.com/adobe/aem-testing-clients/blob/aem-cloud/src/test/java/com/adobe/cq/testing/client/PackageManagerClientTest.java#L64) and leads to this test failure:

```
[INFO] Running com.adobe.cq.testing.client.PackageManagerClientTest
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.208 s <<< FAILURE! - in com.adobe.cq.testing.client.PackageManagerClientTest
[ERROR] testBuildNullPackageFromJson(com.adobe.cq.testing.client.PackageManagerClientTest)  Time elapsed: 0.206 s  <<< ERROR!
java.lang.NullPointerException
	at com.adobe.cq.testing.client.PackageManagerClientTest.testBuildNullPackageFromJson(PackageManagerClientTest.java:100)

[ERROR] testBuildPackageFromJson(com.adobe.cq.testing.client.PackageManagerClientTest)  Time elapsed: 0.002 s  <<< ERROR!
java.lang.NullPointerException
	at com.adobe.cq.testing.client.PackageManagerClientTest.testBuildPackageFromJson(PackageManagerClientTest.java:64)
```

Globally (static) setting the JVM locale to english fixes it. The problem is that already `PackageManagerClient.Package.build(PACKAGE_JSON);` will generate "german" date formats somewhere, hence the global setting.