### PR TITLE
CQ-4310498 CQAssetsClient fails to upload to Azure if admin password includes special characters

### DIFF
--- a/src/test/java/com/adobe/cq/testing/client/PackageManagerClientTest.java
+++ b/src/test/java/com/adobe/cq/testing/client/PackageManagerClientTest.java
@@ -19,11 +19,17 @@ import org.junit.Test;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 
 public class PackageManagerClientTest {
+
+    static {
+        // date formats below are expected to be formatted in english locale
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @Test
     public void testBuildPackageFromJson() throws Exception {


### PR DESCRIPTION
For [CQ-4310498](https://jira.corp.adobe.com/browse/CQ-4310498).

Using a separate HttpClient to prevent sending the AEM Authorization header in the blob store upload requests.

(Note this includes #44)