### PR TITLE
Allow to set "forceBasicAuth" for author and publish instance separately

### DIFF
--- a/src/main/java/com/adobe/cq/testing/junit/rules/CQAuthorPublishClassRule.java
+++ b/src/main/java/com/adobe/cq/testing/junit/rules/CQAuthorPublishClassRule.java
@@ -22,9 +22,6 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import static com.adobe.cq.testing.junit.rules.CQClassRule.DEFAULT_AUTHOR_CONFIG;
-import static com.adobe.cq.testing.junit.rules.CQClassRule.DEFAULT_PUBLISH_CONFIG;
-
 public class CQAuthorPublishClassRule implements TestRule {
 
     /** Granite rules to be executed at class level */
@@ -42,11 +39,22 @@ public class CQAuthorPublishClassRule implements TestRule {
         this(false);
     }
 
+    /**
+     * @param forceBasicAuth Force basic authentication for author and publish instances.
+     */
     public CQAuthorPublishClassRule(boolean forceBasicAuth) {
+        this(forceBasicAuth, forceBasicAuth);
+    }
+
+    /**
+     * @param forceBasicAuthAuthor Force basic authentication for author instance.
+     * @param forceBasicAuthPublish Force basic authentication for publish instance.
+     */
+    public CQAuthorPublishClassRule(boolean forceBasicAuthAuthor, boolean forceBasicAuthPublish) {
         super();
         cqClassRule = new CQClassRule();
-        authorRule = ClassRuleUtils.newInstanceRule(forceBasicAuth).withRunMode("author");
-        publishRule = ClassRuleUtils.newInstanceRule(forceBasicAuth).withRunMode("publish");
+        authorRule = ClassRuleUtils.newInstanceRule(forceBasicAuthAuthor).withRunMode("author");
+        publishRule = ClassRuleUtils.newInstanceRule(forceBasicAuthPublish).withRunMode("publish");
 
         ruleChain = RuleChain.outerRule(cqClassRule)
                 .around(authorRule)


### PR DESCRIPTION
(also remove unused static imports)

background:

if executing request against the publish instance, in most cases we want to use not authentication at all (anonymous access).

for this we use separately for author and publish clients:
```java
  public static void beforeClass() {
    authorClient = CQ_AUTHOR_PUBLISH_CLASS_RULE.getAuthorRule().getAdminClient(ReplicationClient.class);
    publishClient = CQ_AUTHOR_PUBLISH_CLASS_RULE.getPublishRule().getClient(CQClient.class, null, null);
  }
```

this currently fails with aem-cloud-testing-clients 1.0.3 with an endless loop (internally with an NPE in the polling loop), because the token-based authentication is enabled by default for author and publish instance, and this code failes on the publish instance if username and password are explicitly set to null with the code above.

with this PR it is possible to force basic authentication (=disable the token-based author) for author and publish separately, and the code above is working when the class rule is setup with:

```java
  /**
   * The CQAuthorPublishClassRule represents an author and a publish services.
   */
  @ClassRule
  public static final CQAuthorPublishClassRule CQ_AUTHOR_PUBLISH_CLASS_RULE = new CQAuthorPublishClassRule(false, true);
````