### PR TITLE
SecurityClient: Add support for array properties in profiles

### DIFF
--- a/src/main/java/com/adobe/cq/testing/client/security/AbstractProfile.java
+++ b/src/main/java/com/adobe/cq/testing/client/security/AbstractProfile.java
@@ -17,11 +17,11 @@ package com.adobe.cq.testing.client.security;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.sling.testing.clients.ClientException;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.StringJoiner;
 
 /**
  * Define and load authorizable's profile properties
@@ -99,15 +99,11 @@ public class AbstractProfile implements Profile {
         }
     }
 
-    private @NotNull String arrayNodeToString(@NotNull JsonNode node) {
-        StringBuilder sb = new StringBuilder("[");
-        for (int i = 0; i < node.size(); i++) {
-            sb.append(node.get(i).asText());
-            if (i + 1 < node.size()) {
-                sb.append(",");
-            }
+    private String arrayNodeToString(JsonNode node) {
+        StringJoiner sj = new StringJoiner(",", "[", "]");
+        for (final JsonNode val : node) {
+            sj.add(val.asText());
         }
-        sb.append("]");
-        return sb.toString();
+        return sj.toString();
     }
 }

--- a/src/main/java/com/adobe/cq/testing/client/security/AbstractProfile.java
+++ b/src/main/java/com/adobe/cq/testing/client/security/AbstractProfile.java
@@ -17,6 +17,7 @@ package com.adobe.cq.testing.client.security;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.sling.testing.clients.ClientException;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -88,8 +89,25 @@ public class AbstractProfile implements Profile {
         if (profileNode != null) {
             for (Iterator<String> fieldNames = profileNode.fieldNames(); fieldNames.hasNext(); ) {
                 String fieldName = fieldNames.next();
-                profileProps.put(fieldName, profileNode.get(fieldName).textValue());
+                JsonNode fieldNode = profileNode.get(fieldName);
+                if (fieldNode.isArray()){
+                    profileProps.put(fieldName, arrayNodeToString(fieldNode));
+                } else {
+                    profileProps.put(fieldName, fieldNode.textValue());
+                }
             }
         }
+    }
+
+    private @NotNull String arrayNodeToString (@NotNull JsonNode node) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < node.size(); i++) {
+            sb.append(node.get(i).asText());
+            if ( i+1 < node.size()){
+                sb.append(",");
+            }
+        }
+        sb.append("]");
+        return sb.toString();
     }
 }

--- a/src/main/java/com/adobe/cq/testing/client/security/AbstractProfile.java
+++ b/src/main/java/com/adobe/cq/testing/client/security/AbstractProfile.java
@@ -90,7 +90,7 @@ public class AbstractProfile implements Profile {
             for (Iterator<String> fieldNames = profileNode.fieldNames(); fieldNames.hasNext(); ) {
                 String fieldName = fieldNames.next();
                 JsonNode fieldNode = profileNode.get(fieldName);
-                if (fieldNode.isArray()){
+                if (fieldNode.isArray()) {
                     profileProps.put(fieldName, arrayNodeToString(fieldNode));
                 } else {
                     profileProps.put(fieldName, fieldNode.textValue());
@@ -99,11 +99,11 @@ public class AbstractProfile implements Profile {
         }
     }
 
-    private @NotNull String arrayNodeToString (@NotNull JsonNode node) {
+    private @NotNull String arrayNodeToString(@NotNull JsonNode node) {
         StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < node.size(); i++) {
             sb.append(node.get(i).asText());
-            if ( i+1 < node.size()){
+            if (i + 1 < node.size()) {
                 sb.append(",");
             }
         }


### PR DESCRIPTION
Some tests I'm refactoring receive array fields in the user profile.

Those fields need special treatment otherwise, they will be stored as null.

I loop over all elements of the array and build a text representation. This solved the problems in my tests.