### PR TITLE
Fixing adding containsKey check instead of contains for System Properties

### DIFF
--- a/src/main/java/com/adobe/cq/testing/junit/rules/ConfigurableInstance.java
+++ b/src/main/java/com/adobe/cq/testing/junit/rules/ConfigurableInstance.java
@@ -102,7 +102,7 @@ public class ConfigurableInstance extends ExistingInstance {
      * @return true if login token auth is configured
      */
     private static boolean loginTokenAuth() {
-        if (System.getProperties().contains(LOGIN_TOKEN_AUTH)) {
+        if (System.getProperties().containsKey(LOGIN_TOKEN_AUTH)) {
             return Boolean.getBoolean(LOGIN_TOKEN_AUTH);
         } else {
             return true;


### PR DESCRIPTION
Fixing adding containsKey check instead of contains for System Properties , here System properties is hashmap and "Logintokenauth" is a field present in that map , so in hashmap it should check with containsKey not contains to check key is present in hashmap or not.