### PR TITLE
CQ-4312940: Change user-agent of CQ requests to aem-testing-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,19 @@
 
                 </executions>
             </plugin>
+            <!-- Package jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <!-- Include project info in manifest (for user-agent) -->
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
             <!-- Configure release plugin for OSSRH -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.rules</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.sling</groupId>
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.clients</artifactId>
-            <version>3.0.16</version>
+            <version>3.0.18</version>
             <exclusions>
                 <!-- A newer version of servlet-api is included in the dependencies below -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.rules</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.sling</groupId>

--- a/src/main/java/com/adobe/cq/testing/junit/rules/CQClassRule.java
+++ b/src/main/java/com/adobe/cq/testing/junit/rules/CQClassRule.java
@@ -37,7 +37,7 @@ public class CQClassRule implements TestRule {
 
     public final SlingClassRule slingBaseClassRule = new SlingClassRule();
 
-    protected TestRule ruleChain = RuleChain.outerRule(slingBaseClassRule);
+    protected TestRule ruleChain = RuleChain.outerRule(slingBaseClassRule).around(new CQUserAgentRule());
 
     static {
         GraniteBackwardsCompatibility.translateGranitePropertiesToSling();

--- a/src/main/java/com/adobe/cq/testing/junit/rules/CQUserAgentRule.java
+++ b/src/main/java/com/adobe/cq/testing/junit/rules/CQUserAgentRule.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Adobe Systems Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.adobe.cq.testing.junit.rules;
 
 import org.apache.sling.testing.clients.interceptors.UserAgentHolder;

--- a/src/main/java/com/adobe/cq/testing/junit/rules/CQUserAgentRule.java
+++ b/src/main/java/com/adobe/cq/testing/junit/rules/CQUserAgentRule.java
@@ -1,0 +1,36 @@
+package com.adobe.cq.testing.junit.rules;
+
+import org.apache.sling.testing.clients.interceptors.UserAgentHolder;
+import org.apache.sling.testing.clients.util.UserAgentUtil;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class CQUserAgentRule implements TestRule {
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                starting(description);
+                try {
+                    base.evaluate();
+                } finally {
+                    finished();
+                }
+            }
+        };
+    }
+
+    protected void starting(final Description description) {
+        UserAgentHolder.set(
+                UserAgentUtil.constructAgent("aem-testing-client", getClass().getPackage()) +
+                " ("+description.getTestClass().getSimpleName()+")"
+        );
+    }
+
+    protected void finished() {
+        UserAgentHolder.reset();
+    }
+}


### PR DESCRIPTION
~~**Blocked by https://github.com/apache/sling-org-apache-sling-testing-clients/pull/41 and release of [Apache Sling Testing Clients 3.0.18](https://issues.apache.org/jira/issues/?jql=project+%3D+SLING+AND+fixVersion+%3D+%22Apache+Sling+Testing+Clients+3.0.18%22).**~~
~~**Blocked by https://github.com/apache/sling-org-apache-sling-testing-rules/pull/2 and release of Apache Sling Testing Rules 2.0.2.**~~

As part of CQ-4312940 sling testing clients and rules need to be updated to the latest version.
Besides that the user-agent of all CQClient Requests will be changed to `aem-testing-client`.