### PR TITLE
Http clients honor system properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.clients</artifactId>
-            <version>3.0.18</version>
+            <version>3.0.20</version>
             <exclusions>
                 <!-- A newer version of servlet-api is included in the dependencies below -->
                 <exclusion>

--- a/src/main/java/com/adobe/cq/testing/util/LoginUtil.java
+++ b/src/main/java/com/adobe/cq/testing/util/LoginUtil.java
@@ -44,7 +44,7 @@ public class LoginUtil {
      */
     public static HttpResponse doGetWithLoginToken(String loginToken, CQClient cqClient, String testPage) throws IOException {
         // We uses plain Http Client to avoid integration testing framework side effects.
-        HttpClient client = HttpClientBuilder.create().build();
+        HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
 
         HttpGet get = new HttpGet(cqClient.getUrl(testPage));
 
@@ -69,7 +69,7 @@ public class LoginUtil {
      */
     public static <T extends AbstractSlingClient> String getLoginToken(T graniteClient, String targetPage)
             throws IOException {
-        HttpClient client = HttpClientBuilder.create().build();
+        HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
         HttpPost post = buildFormAuthPost(
                 graniteClient,
                 graniteClient.getUser(), graniteClient.getPassword(),


### PR DESCRIPTION
This PR:
* bumps the version of the sling testing clients to honor system properties in https clients ([SLING-12086])
* http clients instantiated directly in the AEM testing clients also honor system properties