### PR TITLE
Update hapi.client dependency to fix CVE-2021-37714

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,19 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
+                <!-- A newer version of hapi.client is included in the dependencies below -->
+                <exclusion>
+                    <groupId>org.apache.sling</groupId>
+                    <artifactId>org.apache.sling.hapi.client</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- New version to fix CVE-2021-37714 of o.a.s.testing.clients -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.hapi.client</artifactId>
+            <version>1.0.2</version>
         </dependency>
 
         <!-- Apache IO utilities -->


### PR DESCRIPTION
Proposing to update the o.a.s.hapi.client dependency to fix CVE-2021-37714.

See: https://issues.apache.org/jira/browse/SLING-12309
See: https://jira.corp.adobe.com/browse/CQ-4357230