### PR TITLE
Resolved Implementation and Design Smells

### DIFF
--- a/src/main/java/com/adobe/cq/testing/client/CommunityClient.java
+++ b/src/main/java/com/adobe/cq/testing/client/CommunityClient.java
@@ -15,6 +15,7 @@
  */
 package com.adobe.cq.testing.client;
 
+import com.adobe.cq.testing.client.model.CommentConfig;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.NameValuePair;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -71,35 +72,34 @@ public class CommunityClient extends CQClient {
      * Configures the Comment component.
      *
      * @param commentPath    path to the comment component
-     * @param defaultMessage the topic for the comments
-     * @param isModerated    true if comments are moderated
-     * @param allowReplies   true if replies are allowed
-     * @param displayAsTree  true if the comments are displayed as tree
-     * @param closed         true if topic is closed (no posting of comments possible anymore)
+     * @param config         configuration options for the comment component
+     *                       (e.g., moderation, replies, tree view, etc.)
      * @param expectedStatus list of allowed HTTP Status to be returned. If not set,
      *                       http status 200 (OK) is assumed.
      * @return Sling response
      * @throws ClientException If something fails during request/response cycle
      */
-    public SlingHttpResponse configureCommentComponent(String commentPath, String defaultMessage,
-                                                       boolean isModerated,
-                                                       boolean allowReplies, boolean displayAsTree, boolean closed,
+    public SlingHttpResponse configureCommentComponent(String commentPath, CommentConfig config,
                                                        int... expectedStatus)
             throws ClientException {
         FormEntityBuilder feb = FormEntityBuilder.create();
         for (NameValuePair val : new SlingParameter("./allowRepliesToComments")
-                .value(Boolean.valueOf(allowReplies).toString()).delete().typeHint("Boolean").toNameValuePairs())
+                .value(Boolean.toString(config.isAllowReplies())).delete().typeHint("Boolean").toNameValuePairs())
             feb.addParameter(val.getName(), val.getValue());
-        for (NameValuePair val : new SlingParameter("./moderateComments").value(Boolean.valueOf(isModerated).toString())
+
+        for (NameValuePair val : new SlingParameter("./moderateComments").value(Boolean.toString(config.isModerated()))
                 .typeHint("Boolean").delete().toNameValuePairs())
             feb.addParameter(val.getName(), val.getValue());
+
         for (NameValuePair val : new SlingParameter("./displayCommentsAsTree")
-                .value(Boolean.valueOf(displayAsTree).toString()).typeHint("Boolean").delete().toNameValuePairs())
+                .value(Boolean.toString(config.isDisplayAsTree())).typeHint("Boolean").delete().toNameValuePairs())
             feb.addParameter(val.getName(), val.getValue());
-        for (NameValuePair val : new SlingParameter("./closed").value(Boolean.valueOf(closed).toString())
+
+        for (NameValuePair val : new SlingParameter("./closed").value(Boolean.toString(config.isClosed()))
                 .typeHint("Boolean").delete().toNameValuePairs())
             feb.addParameter(val.getName(), val.getValue());
-        for (NameValuePair val : new SlingParameter("./defaultMessage").value(defaultMessage).toNameValuePairs())
+
+        for (NameValuePair val : new SlingParameter("./defaultMessage").value(config.getDefaultMessage()).toNameValuePairs())
             feb.addParameter(val.getName(), val.getValue());
 
         return doPost(commentPath, feb.build(), HttpUtils.getExpectedStatus(SC_OK, expectedStatus));

--- a/src/main/java/com/adobe/cq/testing/client/ComponentClient.java
+++ b/src/main/java/com/adobe/cq/testing/client/ComponentClient.java
@@ -16,38 +16,8 @@
 package com.adobe.cq.testing.client;
 
 import com.adobe.cq.testing.client.components.AbstractComponent;
-import com.adobe.cq.testing.client.components.collab.Ratings;
-import com.adobe.cq.testing.client.components.commerce.ShoppingCart;
-import com.adobe.cq.testing.client.components.foundation.Carousel;
-import com.adobe.cq.testing.client.components.foundation.Chart;
-import com.adobe.cq.testing.client.components.foundation.Download;
-import com.adobe.cq.testing.client.components.foundation.External;
-import com.adobe.cq.testing.client.components.foundation.Flash;
-import com.adobe.cq.testing.client.components.foundation.Image;
-import com.adobe.cq.testing.client.components.foundation.List;
-import com.adobe.cq.testing.client.components.foundation.ParSys;
-import com.adobe.cq.testing.client.components.foundation.Reference;
-import com.adobe.cq.testing.client.components.foundation.Search;
-import com.adobe.cq.testing.client.components.foundation.Sitemap;
-import com.adobe.cq.testing.client.components.foundation.Slideshow;
-import com.adobe.cq.testing.client.components.foundation.Table;
-import com.adobe.cq.testing.client.components.foundation.Text;
-import com.adobe.cq.testing.client.components.foundation.TextImage;
-import com.adobe.cq.testing.client.components.foundation.Title;
-import com.adobe.cq.testing.client.components.foundation.form.Address;
-import com.adobe.cq.testing.client.components.foundation.form.Captcha;
-import com.adobe.cq.testing.client.components.foundation.form.Checkbox;
-import com.adobe.cq.testing.client.components.foundation.form.Dropdown;
-import com.adobe.cq.testing.client.components.foundation.form.End;
-import com.adobe.cq.testing.client.components.foundation.form.FileUpload;
-import com.adobe.cq.testing.client.components.foundation.form.Hidden;
-import com.adobe.cq.testing.client.components.foundation.form.ImageButton;
-import com.adobe.cq.testing.client.components.foundation.form.ImageUpload;
-import com.adobe.cq.testing.client.components.foundation.form.Password;
-import com.adobe.cq.testing.client.components.foundation.form.RadioGroup;
-import com.adobe.cq.testing.client.components.foundation.form.Start;
-import com.adobe.cq.testing.client.components.foundation.parsys.ColCtrl;
-import com.adobe.cq.testing.client.components.tagging.TagCloud;
+import com.adobe.cq.testing.client.registry.ComponentRegistry;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.HttpEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -57,7 +27,7 @@ import org.apache.sling.testing.clients.util.FormEntityBuilder;
 
 import java.lang.reflect.Constructor;
 import java.net.URI;
-import java.util.HashMap;
+
 
 public class ComponentClient extends CQClient {
 
@@ -72,51 +42,6 @@ public class ComponentClient extends CQClient {
     public static final String ORDER_LAST = "last";
     public static final String ORDER_BEFORE_PREFIX = "before ";
     public static final String ORDER_AFTER_PREFIX = "after ";
-
-    private static HashMap<String,Class<? extends AbstractComponent>> components = new HashMap<>();
-    // registers all known component wrappers
-    static {
-        // foundation components
-        components.put(Carousel.RESOURCE_TYPE,Carousel.class);
-        components.put(Chart.RESOURCE_TYPE, Chart.class);
-        components.put(ColCtrl.RESOURCE_TYPE,ColCtrl.class);
-        components.put(Download.RESOURCE_TYPE,Download.class);
-        components.put(External.RESOURCE_TYPE,External.class);
-        components.put(Flash.RESOURCE_TYPE,Flash.class);
-        components.put(Image.RESOURCE_TYPE,Image.class);
-        components.put(List.RESOURCE_TYPE,List.class);
-        components.put(Reference.RESOURCE_TYPE,Reference.class);
-        components.put(Search.RESOURCE_TYPE,Search.class);
-        components.put(Sitemap.RESOURCE_TYPE,Sitemap.class);
-        components.put(Slideshow.RESOURCE_TYPE,Slideshow.class);
-        components.put(Table.RESOURCE_TYPE,Table.class);
-        components.put(Text.RESOURCE_TYPE,Text.class);
-        components.put(TextImage.RESOURCE_TYPE,TextImage.class);
-        components.put(Title.RESOURCE_TYPE,Title.class);
-        components.put(TagCloud.RESOURCE_TYPE,TagCloud.class);
-        components.put(ParSys.RESOURCE_TYPE,ParSys.class);
-        // form components
-        components.put(Start.RESOURCE_TYPE,Start.class);
-        components.put(End.RESOURCE_TYPE,End.class);
-        components.put(com.adobe.cq.testing.client.components.foundation.form.Text.RESOURCE_TYPE,
-                com.adobe.cq.testing.client.components.foundation.form.Text.class);
-        components.put(Address.RESOURCE_TYPE,Address.class);
-        components.put(Captcha.RESOURCE_TYPE,Captcha.class);
-        components.put(Checkbox.RESOURCE_TYPE,Checkbox.class);
-        components.put(Dropdown.RESOURCE_TYPE,Dropdown.class);
-        components.put(FileUpload.RESOURCE_TYPE,FileUpload.class);
-        components.put(ImageUpload.RESOURCE_TYPE,ImageUpload.class);
-        components.put(Hidden.RESOURCE_TYPE,Hidden.class);
-        components.put(ImageButton.RESOURCE_TYPE,ImageButton.class);
-        components.put(Password.RESOURCE_TYPE,Password.class);
-        components.put(RadioGroup.RESOURCE_TYPE,RadioGroup.class);
-        components.put(Start.RESOURCE_TYPE,Start.class);
-        // collab components
-        components.put(Ratings.RESOURCE_TYPE,Ratings.class);
-        // commerce components
-        components.put(Address.RESOURCE_TYPE,Address.class);
-        components.put(ShoppingCart.RESOURCE_TYPE,ShoppingCart.class);
-    }
 
     public ComponentClient(CloseableHttpClient http, SlingClientConfig config) throws ClientException {
         super(http, config);
@@ -261,7 +186,8 @@ public class ComponentClient extends CQClient {
                     "sling:resourceType property was found!");
         }
         // get the class
-        Class<? extends AbstractComponent> compClass = getCompClassByResourceType(node.get("sling:resourceType").textValue());
+        String resourceType = node.get("sling:resourceType").textValue();
+        Class<? extends AbstractComponent> compClass = ComponentRegistry.getComponentClass(resourceType);
         
         // no class found ?
         if (compClass == null) return null;
@@ -308,19 +234,7 @@ public class ComponentClient extends CQClient {
      * @param c the corresponding component wrapper class
      */
     public void registerComponent(String resourceType, Class<? extends AbstractComponent> c){
-        components.put(resourceType,c);
-    }
-
-    /**
-     * Returns the component wrapper class, that has been registered with this resourceType or
-     * null if no such resourceType is known. you can register additional component wrappers
-     * using {@link #registerComponent(String, Class)}}.
-     * 
-     * @param resourceType resource type to look up
-     * @return  the corresponding component wrapper class or null if not fund
-     */
-    public Class<? extends AbstractComponent>  getCompClassByResourceType(String resourceType){
-        return components.get(resourceType);
+        ComponentRegistry.registerComponent(resourceType,c);
     }
 
     /**

--- a/src/main/java/com/adobe/cq/testing/client/PackageManagerClient.java
+++ b/src/main/java/com/adobe/cq/testing/client/PackageManagerClient.java
@@ -205,16 +205,17 @@ public class PackageManagerClient extends CQClient {
 
         @Override
         public int hashCode() {
+            final int hash_multiplier = 31;
             int result = path != null ? path.hashCode() : 0;
-            result = 31 * result + (name != null ? name.hashCode() : 0);
-            result = 31 * result + (version != null ? version.hashCode() : 0);
-            result = 31 * result + (group != null ? group.hashCode() : 0);
-            result = 31 * result + (description != null ? description.hashCode() : 0);
-            result = 31 * result + (filter != null ? filter.hashCode() : 0);
-            result = 31 * result + (requiresRestart != null ? requiresRestart.hashCode() : 0);
-            result = 31 * result + (requiresRoot != null ? requiresRoot.hashCode() : 0);
-            result = 31 * result + (buildCount != null ? buildCount.hashCode() : 0);
-            result = 31 * result + (builtWith != null ? builtWith.hashCode() : 0);
+            result = hash_multiplier * result + (name != null ? name.hashCode() : 0);
+            result = hash_multiplier * result + (version != null ? version.hashCode() : 0);
+            result = hash_multiplier * result + (group != null ? group.hashCode() : 0);
+            result = hash_multiplier * result + (description != null ? description.hashCode() : 0);
+            result = hash_multiplier * result + (filter != null ? filter.hashCode() : 0);
+            result = hash_multiplier * result + (requiresRestart != null ? requiresRestart.hashCode() : 0);
+            result = hash_multiplier * result + (requiresRoot != null ? requiresRoot.hashCode() : 0);
+            result = hash_multiplier * result + (buildCount != null ? buildCount.hashCode() : 0);
+            result = hash_multiplier * result + (builtWith != null ? builtWith.hashCode() : 0);
             return result;
         }
 

--- a/src/main/java/com/adobe/cq/testing/client/model/CommentConfig.java
+++ b/src/main/java/com/adobe/cq/testing/client/model/CommentConfig.java
@@ -1,0 +1,57 @@
+package com.adobe.cq.testing.client.model;
+
+/**
+ * Represents configuration options for a comment component.
+ */
+public class CommentConfig {
+    private final String defaultMessage;
+    private final boolean isModerated;
+    private final boolean allowReplies;
+    private final boolean displayAsTree;
+    private final boolean closed;
+
+    public CommentConfig(String defaultMessage, boolean isModerated,
+                         boolean allowReplies, boolean displayAsTree, boolean closed) {
+        this.defaultMessage = defaultMessage;
+        this.isModerated = isModerated;
+        this.allowReplies = allowReplies;
+        this.displayAsTree = displayAsTree;
+        this.closed = closed;
+    }
+    /**
+     * the topic for the comments.
+     */
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+
+    /**
+     * true if comments are moderated.
+     */
+    public boolean isModerated() {
+        return isModerated;
+    }
+
+    /**
+     * true if replies are allowed.
+     */
+    public boolean isAllowReplies() {
+        return allowReplies;
+    }
+
+    /**
+     * true if the comments are displayed as tree.
+     */
+    public boolean isDisplayAsTree() {
+        return displayAsTree;
+    }
+
+    /**
+     * true if topic is closed (no posting of comments possible anymore.
+     */
+    public boolean isClosed() {
+        return closed;
+    }
+}
+
+

--- a/src/main/java/com/adobe/cq/testing/client/registry/ComponentRegistry.java
+++ b/src/main/java/com/adobe/cq/testing/client/registry/ComponentRegistry.java
@@ -1,0 +1,77 @@
+package com.adobe.cq.testing.client.registry;
+
+import com.adobe.cq.testing.client.components.AbstractComponent;
+import com.adobe.cq.testing.client.components.collab.Ratings;
+import com.adobe.cq.testing.client.components.commerce.ShoppingCart;
+import com.adobe.cq.testing.client.components.foundation.*;
+import com.adobe.cq.testing.client.components.foundation.Text;
+import com.adobe.cq.testing.client.components.foundation.form.*;
+import com.adobe.cq.testing.client.components.foundation.parsys.ColCtrl;
+import com.adobe.cq.testing.client.components.tagging.TagCloud;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ComponentRegistry {
+    private static Map<String, Class<? extends AbstractComponent>> components = new HashMap<>();
+    // registers all known component wrappers
+    private ComponentRegistry() {
+        // Prevent instantiation
+    }
+    static {
+        // foundation components
+        components.put(Carousel.RESOURCE_TYPE, Carousel.class);
+        components.put(Chart.RESOURCE_TYPE, Chart.class);
+        components.put(ColCtrl.RESOURCE_TYPE, ColCtrl.class);
+        components.put(Download.RESOURCE_TYPE, Download.class);
+        components.put(External.RESOURCE_TYPE, External.class);
+        components.put(Flash.RESOURCE_TYPE, Flash.class);
+        components.put(Image.RESOURCE_TYPE, Image.class);
+        components.put(List.RESOURCE_TYPE, List.class);
+        components.put(Reference.RESOURCE_TYPE, Reference.class);
+        components.put(Search.RESOURCE_TYPE, Search.class);
+        components.put(Sitemap.RESOURCE_TYPE, Sitemap.class);
+        components.put(Slideshow.RESOURCE_TYPE, Slideshow.class);
+        components.put(Table.RESOURCE_TYPE, Table.class);
+        components.put(Text.RESOURCE_TYPE, Text.class);
+        components.put(TextImage.RESOURCE_TYPE, TextImage.class);
+        components.put(Title.RESOURCE_TYPE, Title.class);
+        components.put(TagCloud.RESOURCE_TYPE, TagCloud.class);
+        components.put(ParSys.RESOURCE_TYPE, ParSys.class);
+
+        // form components
+        components.put(Start.RESOURCE_TYPE, Start.class);
+        components.put(End.RESOURCE_TYPE, End.class);
+        components.put(com.adobe.cq.testing.client.components.foundation.form.Text.RESOURCE_TYPE,
+                com.adobe.cq.testing.client.components.foundation.form.Text.class);
+        components.put(Address.RESOURCE_TYPE, Address.class);
+        components.put(Captcha.RESOURCE_TYPE, Captcha.class);
+        components.put(Checkbox.RESOURCE_TYPE, Checkbox.class);
+        components.put(Dropdown.RESOURCE_TYPE, Dropdown.class);
+        components.put(FileUpload.RESOURCE_TYPE, FileUpload.class);
+        components.put(ImageUpload.RESOURCE_TYPE, ImageUpload.class);
+        components.put(Hidden.RESOURCE_TYPE, Hidden.class);
+        components.put(ImageButton.RESOURCE_TYPE, ImageButton.class);
+        components.put(Password.RESOURCE_TYPE, Password.class);
+        components.put(RadioGroup.RESOURCE_TYPE, RadioGroup.class);
+
+        // collab components
+        components.put(Ratings.RESOURCE_TYPE, Ratings.class);
+
+        // commerce components
+        components.put(Address.RESOURCE_TYPE, Address.class);
+        components.put(ShoppingCart.RESOURCE_TYPE, ShoppingCart.class);
+    }
+
+    public static void registerComponent(String resourceType, Class<? extends AbstractComponent> clazz) {
+        components.put(resourceType, clazz);
+    }
+
+    public static Class<? extends AbstractComponent> getComponentClass(String resourceType) {
+        return components.get(resourceType);
+    }
+
+    public static boolean isComponentRegistered(String resourceType) {
+        return components.containsKey(resourceType);
+    }
+}

--- a/src/main/java/com/adobe/cq/testing/client/security/AbstractAuthorizable.java
+++ b/src/main/java/com/adobe/cq/testing/client/security/AbstractAuthorizable.java
@@ -135,6 +135,8 @@ public abstract class AbstractAuthorizable implements Authorizable {
         return doPost(formEntry, expectedStatus);
     }
 
+    // Provides utility methods to create and retrieve details about users or groups (Authorizable).
+
     public <T extends SecurityClient> Authorizable create(T client,
                                                           Class<? extends AbstractAuthorizable> authorizableClass,
                                                           String authorizableId,
@@ -179,6 +181,7 @@ public abstract class AbstractAuthorizable implements Authorizable {
         }
         return propsNode;
     }
+
 
     /**
      * POST request to AuthorizableServlet.
@@ -324,6 +327,7 @@ public abstract class AbstractAuthorizable implements Authorizable {
             // base path
             authorizablePath = intermediatePath;
         }
+
         authorizablePath += "/" + escapeIllegalJcrChars(authorizableId);
 
         return authorizablePath;
@@ -339,7 +343,6 @@ public abstract class AbstractAuthorizable implements Authorizable {
      * @param authorizableHomePath the home path of the authorizable
      * @return authorizable url
      * @throws ClientException if the request failed
-     *
      */
     protected static String encodePathToURL(String authorizableHomePath) throws ClientException {
         String authorizableUrl = "";
@@ -443,3 +446,5 @@ public abstract class AbstractAuthorizable implements Authorizable {
         return buffer.toString();
     }
 }
+
+

--- a/src/main/java/com/adobe/cq/testing/client/security/AbstractAuthorizable.java
+++ b/src/main/java/com/adobe/cq/testing/client/security/AbstractAuthorizable.java
@@ -144,29 +144,22 @@ public abstract class AbstractAuthorizable implements Authorizable {
     }
 
     public Map<String, Authorizable> getMemberOf() throws ClientException, InterruptedException {
-        JsonNode authorizableNode = JsonUtils.getJsonNodeFromString(getJsonAsString(Authorizable
-                .MEMBER_OF, SC_OK));
-        JsonNode propsNode = null;
-        if (authorizableNode != null) {
-            propsNode = authorizableNode.get(Authorizable.MEMBER_OF);
-        }
-        return buildAuthorizableList(propsNode);
+    return getAuthorizablesByKey(Authorizable.MEMBER_OF);
     }
 
     public Map<String, Authorizable> getMembers() throws ClientException, InterruptedException {
-        JsonNode authorizableNode = JsonUtils.getJsonNodeFromString(getJsonAsString(Authorizable.MEMBERS, SC_OK));
-        JsonNode propsNode = null;
-        if (authorizableNode != null) {
-            propsNode = authorizableNode.get(Authorizable.MEMBERS);
-        }
-        return buildAuthorizableList(propsNode);
+        return getAuthorizablesByKey(Authorizable.MEMBERS);
     }
 
     public Map<String, Authorizable> getImpersonators() throws ClientException, InterruptedException {
-        JsonNode authorizableNode = JsonUtils.getJsonNodeFromString(getJsonAsString(Authorizable.IMPERSONATORS, SC_OK));
+        return getAuthorizablesByKey(Authorizable.IMPERSONATORS);
+    }
+
+    private Map<String, Authorizable> getAuthorizablesByKey(String key) throws ClientException, InterruptedException {
+        JsonNode authorizableNode = JsonUtils.getJsonNodeFromString(getJsonAsString(key, SC_OK));
         JsonNode propsNode = null;
         if (authorizableNode != null) {
-            propsNode = authorizableNode.get(Authorizable.IMPERSONATORS);
+            propsNode = authorizableNode.get(key);
         }
         return buildAuthorizableList(propsNode);
     }
@@ -430,16 +423,19 @@ public abstract class AbstractAuthorizable implements Authorizable {
 
     private static String escapeIllegalJcrChars(String name) {
         final String illegal = "%/:[]*|\t\r\n";
+        final int hex_radix = 16;
+        final int min_length_for_dot = 3;
+        final int buffer_growth_factor = 2;
 
-        StringBuilder buffer = new StringBuilder(name.length() * 2);
+        StringBuilder buffer = new StringBuilder(name.length() * buffer_growth_factor);
         for (int i = 0; i < name.length(); i++) {
             char ch = name.charAt(i);
             if (illegal.indexOf(ch) != -1
-                    || (ch == '.' && name.length() < 3)
+                    || (ch == '.' && name.length() < min_length_for_dot)
                     || (ch == ' ' && (i == 0 || i == name.length() - 1))) {
                 buffer.append('%');
-                buffer.append(Character.toUpperCase(Character.forDigit(ch / 16, 16)));
-                buffer.append(Character.toUpperCase(Character.forDigit(ch % 16, 16)));
+                buffer.append(Character.toUpperCase(Character.forDigit(ch / hex_radix, hex_radix)));
+                buffer.append(Character.toUpperCase(Character.forDigit(ch % hex_radix, hex_radix)));
             } else {
                 buffer.append(ch);
             }

--- a/src/main/java/com/adobe/cq/testing/junit/rules/TemporaryUser.java
+++ b/src/main/java/com/adobe/cq/testing/junit/rules/TemporaryUser.java
@@ -90,33 +90,20 @@ public class TemporaryUser extends ExternalResource {
         CQSecurityClient securityClient = creatorSupplier.get().adaptTo(CQSecurityClient.class);
         Group[] assignedGroups = Arrays.stream(groups).map(getGroupFunction(securityClient)).toArray(Group[]::new);
 
-        class CreateUserPolling extends Polling {
-            String username;
-            String password;
-            User user;
+        String[] username = new String[1];
+        String[] password = new String[1];
+        User[] createdUser = new User[1];
 
-            @Override
-            public Boolean call() throws Exception {
-                username = generateName();
-                password = generatePassword();
-                usersToDelete.get().add(username);
-                user = securityClient.createUser(username, password, assignedGroups);
-                return true;
-            }
-        }
+        new Polling(() -> {
+            username[0] = generateName();
+            password[0] = generatePassword();
+            usersToDelete.get().add(username[0]);
+            createdUser[0] = securityClient.createUser(username[0], password[0], assignedGroups);
+            return true;
+        }).poll(SECONDS.toMillis(20), SECONDS.toMillis(1));
 
-        CreateUserPolling p = new CreateUserPolling();
-        try {
-            p.poll(SECONDS.toMillis(20), SECONDS.toMillis(1));
-        } catch (TimeoutException e) {
-            LOG.error("Timeout of 20s reached while trying to create user." +
-                    " List of exceptions: " + p.getExceptions(), e);
-            deleteUsers();
-            throw e;
-        }
-
-        LOG.info("Created user {} at {}", p.user.getId(), p.user.getHomePath());
-        userClient.set(new CQClient(securityClient.getUrl(), p.username, p.password));
+        LOG.info("Created user {} at {}", createdUser[0].getId(), createdUser[0].getHomePath());
+        userClient.set(new CQClient(securityClient.getUrl(), username[0] ,password[0]));
     }
 
     @Override


### PR DESCRIPTION
Commit 1 - [Implementation Smell1 - found magic number](https://github.com/adobe/aem-testing-clients/commit/908c2865ae160a9b8891d0c42727f5ee50900054)
Description - I refactored the magic number of hashcode( ) function.
Commit 2 - [Implementation Smell2 - found magic number](https://github.com/adobe/aem-testing-clients/commit/ac30e42c601210f4343f379d4a02830405dbeefc)
Description - I refactored the magic number in escapeIllegalJcrChars( ) method.
Commit 3 - [Implementation Smell3 - found repeatitive code](https://github.com/adobe/aem-testing-clients/commit/9a16eb1a47c781ea35223f383a1df5b6a67c8e9f)
Description - I extracted the reusable logic of Authorizable.
Commit 4 - [Design Smell1 - found unnecessary abstraction](https://github.com/adobe/aem-testing-clients/commit/702334ab6b0d2ddc125c89355fb36abf9fdc53c9)
Description - I have refactored the unecessary abstarction in before( ).
Commit 5 - [Design Smell2 - found Cyclically-dependent Modularization](https://github.com/adobe/aem-testing-clients/commit/0217296504730f41f36bf6b53f98f8bd94a27241)
Description - I have created separated class file to remove the cyclic dependency of ComponentClient.
Commit 6 - [Design Smell3 - found Primitive Obession](https://github.com/adobe/aem-testing-clients/commit/61f26831bb5b1db2aad7bb1eefea4691f6b10f4f)
Description - I have created separate class file to remove primitive datatypes in CommunityClient.