### PR TITLE
update dependencies / migrate to WireMock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
     # specify the version you desire here
-    - image: circleci/openjdk:8-jdk
+    - image: circleci/openjdk:11-jdk
 
     # Specify service dependencies here if necessary
     # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
     # specify the version you desire here
-    - image: circleci/openjdk:11-jdk
+    - image: cimg/openjdk:11.0
 
     # Specify service dependencies here if necessary
     # CircleCI maintains a library of pre-built images

--- a/pom.xml
+++ b/pom.xml
@@ -54,17 +54,6 @@
         <tag>aem-cloud-testing-clients-1.2.8</tag>
     </scm>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson.version>2.19.1</jackson.version>
@@ -216,7 +205,17 @@
                             </execution>
                         </executions>
                     </plugin>
-
+                    <!-- Push to Maven central -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <waitUntil>published</waitUntil>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.57.v20241219</jetty.version>
-        <jackson.version>2.18.3</jackson.version>
+        <jackson.version>2.19.1</jackson.version>
     </properties>
 
     <build>
@@ -77,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven-version</id>
@@ -100,9 +99,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <release>8</release>
-                    <source>8</source>
-                    <target>8</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <!-- Always generate javadoc jar to catch errors early -->
@@ -208,7 +205,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.7</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -267,7 +264,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.18.0</version>
+            <version>2.19.0</version>
         </dependency>
 
         <!-- Required by WorkflowClient -->
@@ -288,7 +285,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.12.1</version>
+            <version>2.13.1</version>
         </dependency>
 
         <!-- For @Nullable annotations -->
@@ -350,59 +347,16 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.11.0</version>
+            <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
 
-        <!-- Use Spark as a mock server for unit tests -->
+        <!-- Use WireMock as a mock server for unit tests -->
         <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.9.4</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-http</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-util</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-xml</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-http</artifactId>
-            <version>${jetty.version}</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>3.13.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-xml</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/src/main/java/com/adobe/cq/testing/util/WCMCommands.java
+++ b/src/main/java/com/adobe/cq/testing/util/WCMCommands.java
@@ -545,7 +545,7 @@ public class WCMCommands {
         // title of new launch section
         feb.addParameter("path", path);
 
-        return executeWCMCommand(CMD_CREATE_LAUNCH, feb, expectedStatus);
+        return executeWCMCommand(CMD_DELETE_LAUNCH, feb, expectedStatus);
     }
 
 

--- a/src/test/java/com/adobe/cq/testing/client/TogglesClientTest.java
+++ b/src/test/java/com/adobe/cq/testing/client/TogglesClientTest.java
@@ -1,9 +1,9 @@
 package com.adobe.cq.testing.client;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import spark.Spark;
 
 import java.net.URI;
 import java.util.List;
@@ -11,35 +11,32 @@ import java.util.List;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static spark.Spark.awaitInitialization;
-import static spark.Spark.get;
-import static spark.Spark.port;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 public class TogglesClientTest {
 
-    @BeforeClass
-    public static void startServer() {
-        port(0);
-        get("etc.clientlibs/toggles.json", (req, res) -> "{\"enabled\":[\"a\", \"b\", \"c\"]}");
-        awaitInitialization();
-    }
+    @Rule
+    public WireMockRule togglesService = new WireMockRule();
 
-    @AfterClass
-    public static void stopServer() {
-        Spark.stop();
-        Spark.awaitStop();
+    @Before
+    public void startServer() {
+        togglesService.stubFor(get(urlEqualTo("/etc.clientlibs/toggles.json"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"enabled\":[\"a\", \"b\", \"c\"]}")));
     }
 
     @Test
     public void testGetEnabledToggles() throws Exception {
-        TogglesClient client = new TogglesClient(URI.create(String.format("http://localhost:%d", port())), "", "");
+        TogglesClient client = new TogglesClient(URI.create(String.format("http://localhost:%d", togglesService.port())), "", "");
         List<String> toggles = client.getEnabledToggles();
         assertArrayEquals(toggles.toArray(), new String[]{"a", "b", "c"});
     }
 
     @Test
     public void testIsToggleEnabled() throws Exception {
-        TogglesClient client = new TogglesClient(URI.create(String.format("http://localhost:%d", port())), "", "");
+        TogglesClient client = new TogglesClient(URI.create(String.format("http://localhost:%d", togglesService.port())), "", "");
         assertTrue(client.isToggleEnabled("a"));
         assertFalse(client.isToggleEnabled("e"));
     }

--- a/src/test/java/com/adobe/cq/testing/client/TogglesClientTest.java
+++ b/src/test/java/com/adobe/cq/testing/client/TogglesClientTest.java
@@ -8,10 +8,10 @@ import org.junit.Test;
 import java.net.URI;
 import java.util.List;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 public class TogglesClientTest {
 

--- a/src/test/java/com/adobe/cq/testing/junit/rules/TemporaryUserTest.java
+++ b/src/test/java/com/adobe/cq/testing/junit/rules/TemporaryUserTest.java
@@ -1,47 +1,44 @@
 package com.adobe.cq.testing.junit.rules;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingClient;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
-import spark.Spark;
 
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static spark.Spark.get;
-import static spark.Spark.port;
-import static spark.Spark.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 
 public class TemporaryUserTest {
 
-    @Before
-    public void startServer() {
-        port(0);
-    }
-
-    @After
-    public void stopServer() {
-        Spark.stop();
-        Spark.awaitStop();
-    }
+    @Rule
+    public WireMockRule aemService = new WireMockRule();
 
     @Test
     public void testUserIsCreated() throws Throwable {
-        get("/libs/granite/security/search/authorizables.json",
-                (req, res) -> "{ \"authorizables\": [{ \"home\": \"/home/users/dummy\"}] }");
-        post("/libs/granite/security/post/authorizables.html", (req, res) -> {
-            res.status(201);
-            return "{}";
-        });
-        post("/home/users/dummy.rw.html", (req, res) -> "{}");
-        Spark.awaitInitialization();
+        aemService.stubFor(get(urlPathEqualTo("/libs/granite/security/search/authorizables.json"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"authorizables\": [{ \"home\": \"/home/users/dummy\"}] }")));
+        aemService.stubFor(post(urlEqualTo("/libs/granite/security/post/authorizables.html"))
+                .willReturn(aResponse()
+                        .withStatus(201)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
+        aemService.stubFor(post(urlEqualTo("/home/users/dummy.rw.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
 
         TemporaryUser temporaryUserRule = new TemporaryUser(() -> {
             try {
-                return new SlingClient(URI.create(String.format("http://localhost:%d", port())),"","");
+                return new SlingClient(URI.create(String.format("http://localhost:%d", aemService.port())),"","");
             } catch (ClientException e) {
                 e.printStackTrace();
                 return null;
@@ -62,45 +59,69 @@ public class TemporaryUserTest {
         AtomicInteger checkUserCalls = new AtomicInteger();
         AtomicInteger createUserCalls = new AtomicInteger();
 
-        get("/libs/granite/security/search/authorizables.json", (req, res) -> {
+        aemService.stubFor(get(urlPathEqualTo("/libs/granite/security/search/authorizables.json"))
+                .withQueryParam("query", equalTo("{\"condition\":[{\"named\":\"my-group\"}]}"))
+                .inScenario("get-groups")
+                .whenScenarioStateIs(STARTED)
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withBody(""))
+                .willSetStateTo("retry"));
+        aemService.stubFor(get(urlPathEqualTo("/libs/granite/security/search/authorizables.json"))
+                .withQueryParam("query", equalTo("{\"condition\":[{\"named\":\"my-group\"}]}"))
+                .inScenario("get-groups")
+                .whenScenarioStateIs("retry")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"authorizables\":[{\"home\":\"/home/groups/my-group\"}]}")));
 
-            if (req.queryParams("query").equals("{\"condition\":[{\"named\":\"my-group\"}]}")) {
-                // Request to instantiate the Group
-                if (getGroupCalls.incrementAndGet() == 1) {
-                    res.status(500);
-                    return "";
-                }
-                return "{ \"authorizables\": [{ \"home\": \"/home/groups/my-group\"}] }";
-            } else if (req.queryParams("query").contains("testuser")) {
-                // Request to check that the user exists
-                if (checkUserCalls.incrementAndGet() == 1) {
-                    res.status(404);
-                    return "";
-                }
+        aemService.stubFor(get(urlPathEqualTo("/libs/granite/security/search/authorizables.json"))
+                .withQueryParam("query", containing("testuser"))
+                .inScenario("get-user")
+                .whenScenarioStateIs(STARTED)
+                .willReturn(aResponse()
+                        .withStatus(404)
+                        .withBody(""))
+                .willSetStateTo("retry"));
+        aemService.stubFor(get(urlPathEqualTo("/libs/granite/security/search/authorizables.json"))
+                .withQueryParam("query", containing("testuser"))
+                .inScenario("get-user")
+                .whenScenarioStateIs("retry")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"authorizables\": [{ \"home\": \"/home/user/a/abcdef\"}] }")));
 
-                return "{ \"authorizables\": [{ \"home\": \"/home/user/a/abcdef\"}] }";
-            }
+        aemService.stubFor(post(urlEqualTo("/libs/granite/security/post/authorizables.html"))
+                .inScenario("create-user")
+                .whenScenarioStateIs(STARTED)
+                .willReturn(aResponse()
+                        .withStatus(407)
+                        .withBody(""))
+                .willSetStateTo("retry"));
+        aemService.stubFor(post(urlEqualTo("/libs/granite/security/post/authorizables.html"))
+                .inScenario("create-user")
+                .whenScenarioStateIs("retry")
+                .willReturn(aResponse()
+                        .withStatus(201)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
 
-            res.status(400);
-            return "";
-        });
-        post("/libs/granite/security/post/authorizables.html", (req, res) -> {
-            // Request to create the user
-            if (createUserCalls.incrementAndGet() == 1) {
-                res.status(407);
-                return "";
-            }
-
-            res.status(201);
-            return "{}";
-        });
-        post("/home/groups/my-group.rw.html", (req, res) -> "{}"); // Upgrade Group
-        post("/home/user/a/abcdef.rw.html", (req, res) -> "{}"); // Delete User
-        Spark.awaitInitialization();
+        aemService.stubFor(post(urlEqualTo("/home/groups/my-group.rw.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
+        aemService.stubFor(post(urlEqualTo("/home/user/a/abcdef.rw.html"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{}")));
 
         TemporaryUser temporaryUserRule = new TemporaryUser(() -> {
             try {
-                return new SlingClient(URI.create(String.format("http://localhost:%d", port())),"","");
+                return new SlingClient(URI.create(String.format("http://localhost:%d", aemService.port())),"","");
             } catch (ClientException e) {
                 e.printStackTrace();
                 return null;

--- a/src/test/java/com/adobe/cq/testing/junit/rules/TemporaryUserTest.java
+++ b/src/test/java/com/adobe/cq/testing/junit/rules/TemporaryUserTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.junit.runners.model.Statement;
 
 import java.net.URI;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
@@ -38,7 +37,7 @@ public class TemporaryUserTest {
 
         TemporaryUser temporaryUserRule = new TemporaryUser(() -> {
             try {
-                return new SlingClient(URI.create(String.format("http://localhost:%d", aemService.port())),"","");
+                return new SlingClient(URI.create(String.format("http://localhost:%d", aemService.port())), "", "");
             } catch (ClientException e) {
                 e.printStackTrace();
                 return null;
@@ -55,10 +54,6 @@ public class TemporaryUserTest {
 
     @Test
     public void testAuthorizableInstability() throws Throwable {
-        AtomicInteger getGroupCalls = new AtomicInteger();
-        AtomicInteger checkUserCalls = new AtomicInteger();
-        AtomicInteger createUserCalls = new AtomicInteger();
-
         aemService.stubFor(get(urlPathEqualTo("/libs/granite/security/search/authorizables.json"))
                 .withQueryParam("query", equalTo("{\"condition\":[{\"named\":\"my-group\"}]}"))
                 .inScenario("get-groups")
@@ -121,7 +116,7 @@ public class TemporaryUserTest {
 
         TemporaryUser temporaryUserRule = new TemporaryUser(() -> {
             try {
-                return new SlingClient(URI.create(String.format("http://localhost:%d", aemService.port())),"","");
+                return new SlingClient(URI.create(String.format("http://localhost:%d", aemService.port())), "", "");
             } catch (ClientException e) {
                 e.printStackTrace();
                 return null;
@@ -134,5 +129,15 @@ public class TemporaryUserTest {
             }
         }, null);
         statement.evaluate();
+
+        verify(exactly(2),
+                getRequestedFor(urlPathEqualTo("/libs/granite/security/search/authorizables.json"))
+                        .withQueryParam("query", equalTo("{\"condition\":[{\"named\":\"my-group\"}]}")));
+        verify(exactly(6),
+                getRequestedFor(urlPathEqualTo("/libs/granite/security/search/authorizables.json"))
+                        .withQueryParam("query", containing("testuser")));
+        verify(exactly(2), postRequestedFor(urlEqualTo("/libs/granite/security/post/authorizables.html")));
+        verify(exactly(1), postRequestedFor(urlEqualTo("/home/groups/my-group.rw.html")));
+        verify(exactly(2), postRequestedFor(urlEqualTo("/home/user/a/abcdef.rw.html")));
     }
 }

--- a/src/test/java/com/adobe/cq/testing/junit/rules/toggles/TogglesAwareTestRuleTest.java
+++ b/src/test/java/com/adobe/cq/testing/junit/rules/toggles/TogglesAwareTestRuleTest.java
@@ -1,40 +1,30 @@
 package com.adobe.cq.testing.junit.rules.toggles;
 
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.sling.testing.clients.ClientException;
 import org.apache.sling.testing.clients.SlingClient;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 
 import java.net.URI;
 
 import static org.junit.Assert.fail;
-import static spark.Spark.awaitInitialization;
-import static spark.Spark.awaitStop;
-import static spark.Spark.get;
-import static spark.Spark.port;
-import static spark.Spark.stop;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 public class TogglesAwareTestRuleTest {
 
-    @BeforeClass
-    public static void startServer() {
-        port(0);
-        get("etc.clientlibs/toggles.json", (req, res) -> "{\"enabled\":[\"a\", \"b\", \"c\"]}");
-        awaitInitialization();
-    }
-
-    @AfterClass
-    public static void stopServer() {
-        stop();
-        awaitStop();
-    }
+    @ClassRule
+    public static WireMockRule togglesService = new WireMockRule();
 
     @Rule
     public TogglesAwareTestRule togglesAwareTestRule = new TogglesAwareTestRule(() -> {
+        togglesService.stubFor(get(urlEqualTo("/etc.clientlibs/toggles.json"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"enabled\":[\"a\", \"b\", \"c\"]}")));
+
         try {
-            return new SlingClient(URI.create(String.format("http://localhost:%d", port())), "", "");
+            return new SlingClient(URI.create(String.format("http://localhost:%d", togglesService.port())), "", "");
         } catch (ClientException e) {
             return null;
         }

--- a/src/test/java/com/adobe/cq/testing/junit/rules/toggles/TogglesAwareTestRuleTest.java
+++ b/src/test/java/com/adobe/cq/testing/junit/rules/toggles/TogglesAwareTestRuleTest.java
@@ -7,8 +7,8 @@ import org.junit.*;
 
 import java.net.URI;
 
-import static org.junit.Assert.fail;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.fail;
 
 public class TogglesAwareTestRuleTest {
 


### PR DESCRIPTION
unit tests were using Spark Java framework which is not maintained anymore since 3 years and embed a very old Jetty version.
It's only a test dependency though some vulnerability was reported.

Thus updating dependencies and switching to WireMock which embeds a later version of Jetty